### PR TITLE
redefine swin_attention and operator

### DIFF
--- a/mondrian/attention/swin_func_self_attention.py
+++ b/mondrian/attention/swin_func_self_attention.py
@@ -49,8 +49,7 @@ class SwinFuncSelfAttention(nn.Module):
 
       if self.shift_size > 0:
         # calculate attention mask for SW-MSA
-        H, W = self.n_sub_y, self.n_sub_x
-        img_mask = torch.zeros((1, 1, H, W))
+        img_mask = torch.zeros((1, 1, self.n_sub_y, self.n_sub_x))
         h_slices = (slice(0, -self.window_size),
                     slice(-self.window_size, -self.shift_size),
                     slice(-self.shift_size, None))
@@ -63,7 +62,7 @@ class SwinFuncSelfAttention(nn.Module):
                 img_mask[:,:, h, w] = cnt
                 cnt += 1
 
-        mask_windows = win_decompose2d(img_mask, H, W, self.window_size)
+        mask_windows = win_decompose2d(img_mask, self.n_sub_y, self.n_sub_x, self.window_size)
         mask_windows = mask_windows.view(-1, self.window_size * self.window_size)
         
         attn_mask = mask_windows.unsqueeze(1) - mask_windows.unsqueeze(2)


### PR DESCRIPTION
# Changes
- ## `swin_func_self_attention`
Removed overriding func_self_attention and added init  stuff 
- ## `swin_sa_operator_2d`
Removed `SequenceInstanceNorm2d` and added `SequenceGroupNorm2d` and changed input_project and output_project layer from `PointwiseMLP2d` to `get_default_feed_forward_operator` and added positional embedding.